### PR TITLE
More entity data and client for reporting Durable Entity status

### DIFF
--- a/RetryTimeoutCallback/FunctionApp/Activities/CallApiActivity.cs
+++ b/RetryTimeoutCallback/FunctionApp/Activities/CallApiActivity.cs
@@ -12,7 +12,7 @@ namespace FunctionApp.Activities
     public static class CallApiActivity
     {
         [FunctionName(nameof(CallApiActivity))]
-        public async static Task<HttpStatusCode> CallApi([ActivityTrigger] IDurableActivityContext context)
+        public async static Task<(HttpStatusCode, string)> CallApi([ActivityTrigger] IDurableActivityContext context)
         {
             // Get input
             var input = context.GetInput<CallApiActivityInput>();
@@ -30,10 +30,13 @@ namespace FunctionApp.Activities
 
             // Make request to api
             using var httpClient = new HttpClient();
-            var response = await httpClient.PostAsJsonAsync("http://localhost:5000/api/Job", instructions);
-            
-            // Return status code
-            return response.StatusCode;
+            var responseMessage = await httpClient.PostAsJsonAsync("http://localhost:5000/api/Job", instructions);
+
+            // Prepare tuple to return
+            var response = (StatusCode: responseMessage.StatusCode, StatusText: responseMessage.ReasonPhrase);
+
+            // Return
+            return response;
         }
     }
 }

--- a/RetryTimeoutCallback/FunctionApp/Clients/HttpAttemptCounterEntityClient.cs
+++ b/RetryTimeoutCallback/FunctionApp/Clients/HttpAttemptCounterEntityClient.cs
@@ -4,7 +4,6 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -13,7 +12,7 @@ namespace FunctionApp.Clients
     public class HttpAttemptCounterEntityClient
     {
         /// <summary>
-        /// Returns the latest commited entity state for the given instanceid. Expect GET request /api/HttpAttemptCounterEntityClient?instanceid=[instanceidhere]
+        /// Returns the latest commited entity state for the given instanceid. Expects GET request /api/HttpAttemptCounterEntityClient?instanceid=[instanceidhere]
         /// </summary>
         /// <param name="req">HttpRequestMessage.</param>
         /// <param name="client">IDurableEntityClient.</param>

--- a/RetryTimeoutCallback/FunctionApp/Clients/HttpAttemptCounterEntityClient.cs
+++ b/RetryTimeoutCallback/FunctionApp/Clients/HttpAttemptCounterEntityClient.cs
@@ -1,0 +1,42 @@
+﻿using FunctionApp.Entities;
+using FunctionApp.Models;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace FunctionApp.Clients
+{
+    public class HttpAttemptCounterEntityClient
+    {
+        /// <summary>
+        /// Returns the latest commited entity state for the given instanceid. Expect GET request /api/HttpAttemptCounterEntityClient?instanceid=[instanceidhere]
+        /// </summary>
+        /// <param name="req">HttpRequestMessage.</param>
+        /// <param name="client">IDurableEntityClient.</param>
+        /// <param name="log">ILogger.</param>
+        /// <returns>The latest commmited AttemptCounterEntityState for the given orchestration instance id.</returns>
+        [FunctionName(nameof(HttpAttemptCounterEntityClient))]
+        public static async Task<AttemptCounterEntityState> HttpAttemptCounterEntity(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestMessage req,
+            [DurableClient] IDurableEntityClient client,
+            ILogger log)
+        {
+            // Get insanceId from input payload
+            var queryString = req.RequestUri.ParseQueryString();
+            var instanceId = queryString["instanceid"];
+
+            // Setup entity ID key'd from the orchestration instance id. One counter per orchestration instance.
+            var attemptCounterEntityId = new EntityId(nameof(AttemptCounterEntity), instanceId);
+
+            // get entity state
+            var stateResponse = await client.ReadEntityStateAsync<AttemptCounterEntityState>(attemptCounterEntityId);
+
+            // Return
+            return stateResponse.EntityState;
+        }
+    }
+}

--- a/RetryTimeoutCallback/FunctionApp/Entities/AttemptCounterEntity.cs
+++ b/RetryTimeoutCallback/FunctionApp/Entities/AttemptCounterEntity.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using static FunctionApp.Models.AttemptCounterEntityState;
 
@@ -21,6 +22,15 @@ namespace FunctionApp.Entities
             }
             newAttempt.Order = this.Attempts.Count + 1;
             this.Attempts.Add(newAttempt);
+        }
+
+        public void UpdateAttempt(Attempt attempt)
+        {
+            // Remove the existing attempt(s) at this position
+            this.Attempts.RemoveAll(a => a.Order == attempt.Order);
+
+            // Add new attempt
+            this.Attempts.Add(attempt);
         }
 
         public Task Reset()

--- a/RetryTimeoutCallback/FunctionApp/Entities/AttemptCounterEntity.cs
+++ b/RetryTimeoutCallback/FunctionApp/Entities/AttemptCounterEntity.cs
@@ -20,14 +20,13 @@ namespace FunctionApp.Entities
             {
                 this.Attempts = new List<Attempt>();
             }
-            newAttempt.Order = this.Attempts.Count + 1;
             this.Attempts.Add(newAttempt);
         }
 
         public void UpdateAttempt(Attempt attempt)
         {
-            // Remove the existing attempt(s) at this position
-            this.Attempts.RemoveAll(a => a.Order == attempt.Order);
+            // Remove the existing attempt(s) with this ID
+            this.Attempts.RemoveAll(a => a.Id == attempt.Id);
 
             // Add new attempt
             this.Attempts.Add(attempt);

--- a/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
+++ b/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace FunctionApp.Models
 {
@@ -17,6 +18,7 @@ namespace FunctionApp.Models
             public DateTime DateTimeStarted;
             public string State;
             public string StatusText;
+            public HttpStatusCode? StatusCode { get; set; }
         }
     }
 }

--- a/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
+++ b/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
@@ -14,11 +14,11 @@ namespace FunctionApp.Models
         [JsonObject(MemberSerialization = MemberSerialization.OptOut)]
         public struct Attempt
         {
-            public int Order;
+            public Guid Id;
             public DateTime DateTimeStarted;
             public string State;
             public string StatusText;
-            public HttpStatusCode? StatusCode { get; set; }
+            public HttpStatusCode? StatusCode;
         }
     }
 }

--- a/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
+++ b/RetryTimeoutCallback/FunctionApp/Models/AttemptCounterEntityState.cs
@@ -1,17 +1,22 @@
 ﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 
 namespace FunctionApp.Models
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class AttemptCounterEntityState
     {
-        [JsonProperty("attemptsCount")]
-        public int AttemptsCount { get; set; }
+        [JsonProperty("attempts")]
+        public List<Attempt> Attempts { get; set; } = new List<Attempt>();
 
-        [JsonProperty("timeoutsCount")]
-        public int TimeoutsCount { get; set; }
-
-        [JsonProperty("errorsCount")]
-        public int ErrorsCount { get; set; }
+        [JsonObject(MemberSerialization = MemberSerialization.OptOut)]
+        public struct Attempt
+        {
+            public int Order;
+            public DateTime DateTimeStarted;
+            public string State;
+            public string StatusText;
+        }
     }
 }

--- a/RetryTimeoutCallback/FunctionApp/Orchestrators/MainOrchestrator.cs
+++ b/RetryTimeoutCallback/FunctionApp/Orchestrators/MainOrchestrator.cs
@@ -58,8 +58,8 @@ namespace FunctionApp.Orchestrators
                 // Increment attempt counter
                 var thisAttempt = new Attempt() 
                 {
+                    Id = context.NewGuid(),
                     DateTimeStarted = context.CurrentUtcDateTime,
-                    Order = default, // Will get over-written by the entity based on number of existing Attempt
                     State = "new",
                     StatusText = string.Empty,
                     StatusCode = null,

--- a/RetryTimeoutCallback/FunctionApp/Orchestrators/MainOrchestrator.cs
+++ b/RetryTimeoutCallback/FunctionApp/Orchestrators/MainOrchestrator.cs
@@ -82,12 +82,13 @@ namespace FunctionApp.Orchestrators
                 // Wait for the api to call back
                 try
                 {
+                    thisAttempt.State = "waiting";
+                    context.SignalEntity(attemptCounterEntityId, "UpdateAttempt", thisAttempt);
+
                     // This line will make the function wait for the callback event.
                     // This is a manual act that you can use postman or any api tool for.
                     // Do a POST request to the value of callBackUrlBuilder.ToString() (see debug console). Attach a json body with the word "true" in the body without any json structure.
                     await context.WaitForExternalEvent<bool>(Constants.CallbackEventName, new TimeSpan(0, 0, _timeoutLimitSeconds));
-                    thisAttempt.State = "waiting";
-                    context.SignalEntity(attemptCounterEntityId, "UpdateAttempt", thisAttempt);
                 }
                 catch (TimeoutException)
                 {


### PR DESCRIPTION
This PR refactors the way the durable entity stores state so that a greater range of state information can be stored for each attempt. Closes #1 

This PR also adds a HTTP client function which gets the latest durable entity state which is good for testing. Closes #2 